### PR TITLE
Catch all exceptions thrown in ValueOfType

### DIFF
--- a/Assets/DarkConfig/ConfigReifier.cs
+++ b/Assets/DarkConfig/ConfigReifier.cs
@@ -275,7 +275,7 @@ namespace DarkConfig {
                         return CallPostDoc(fieldType, existing);
                     }
                 }
-            } catch (FormatException e) {
+            } catch (Exception e) {
                 throw new ParseException("Exception based on document starting at: " + value.SourceInformation, e);
             }
 

--- a/Assets/Editor/Tests/ConfigReifierFacts.cs
+++ b/Assets/Editor/Tests/ConfigReifierFacts.cs
@@ -1088,5 +1088,25 @@ class ConfigReifierFacts {
         Assert.AreEqual(d["ugh"].AsString(), "bugh");
     }
 
+    [Test]
+    public void ParseException_EmptyEnum() {
+        Assert.Throws<ParseException>(() => {
+            ReifyString<TestClass>("enumKey: \"\"");
+        });
+    }
+
+    [Test]
+    public void ParseException_BadInt() {
+        Assert.Throws<ParseException>(() => {
+            ReifyString<TestClass>("intKey: incorrect");
+        });
+    }
+
+    [Test]
+    public void ParseException_BadBool() {
+        Assert.Throws<ParseException>(() => {
+            ReifyString<TestClass>("boolKeyDefaultFalse: incorrect");
+        });
+    }
     
 }


### PR DESCRIPTION
It seems like a heavy hammer to catch all exceptions in this one clause, but I think it's one of the rare cases where it's what we really want to do, because we're just annotating the exception with source information.

I'm not under the impression that this will provide source information for every case where we currently don't, but it's a start.