### PR TITLE
Fix failing test

### DIFF
--- a/Assets/Editor/Tests/FromDocFacts.cs
+++ b/Assets/Editor/Tests/FromDocFacts.cs
@@ -110,8 +110,8 @@ class FromDocFacts {
     }
 
     [Test]
-    [ExpectedException(typeof(System.ArgumentException))]
-    public void FromDoc_PassesAlongExceptions() {
+    [ExpectedException(typeof(ParseException))]
+    public void FromDoc_WrapsExceptions() {
         ReifyString<TestClass>("{\"wrong\": \"structure\"}");
     }
 


### PR DESCRIPTION
I don’t think there was ever a use case for FromDoc exceptions being passed through unmodified (and they kinda weren’t before, if your FromDoc threw a FormatException).  I think it was just a case of a unit test baking in an assumption.  And now we’re baking in a different assumption!