### PR TITLE
NUnit breaking api changes in Unity 5.6 update (NUnit3)

### DIFF
--- a/Assets/Editor/Tests/FromDocFacts.cs
+++ b/Assets/Editor/Tests/FromDocFacts.cs
@@ -109,11 +109,20 @@ class FromDocFacts {
         Assert.IsTrue(tc is TestClassDerived);
     }
 
+#if UNITY_5_6
+    [Test]
+    public void FromDoc_WrapsExceptions() {
+        Assert.That(() => {
+            ReifyString<TestClass>("{\"wrong\": \"structure\"}");
+        }, Throws.TypeOf<ParseException>());
+    }
+#else
     [Test]
     [ExpectedException(typeof(ParseException))]
     public void FromDoc_WrapsExceptions() {
         ReifyString<TestClass>("{\"wrong\": \"structure\"}");
     }
+#endif
 
     [Test]
     public void FromDoc_CalledWhenReifyingNullClass() {


### PR DESCRIPTION
Unity 5.6 updated NUnit to version 3 which has breaking api changes.

http://answers.unity3d.com/questions/1333717/56-nunits-expectedexception-attribute-is-gone.html