### PR TITLE
DarkConfig 2 Improvements

### DIFF
--- a/Docs/migrating_from_v1.md
+++ b/Docs/migrating_from_v1.md
@@ -1,0 +1,13 @@
+# Migrating from DarkConfig v1
+
+DarkConfig v2 introduces some breaking API changes. This is a quick guide on migrating from v1
+
+- `DarkConfig.Config` is now `DarkConfig.Configs`
+- `Config.Load()` is now `Configs.ParseFile()`
+- `ConfigReifier.Reify()` is now `Configs.Reify()`
+- 2D arrays are transposed compared to pre-migration. See: https://github.com/SpryFox/DarkConfig/issues/28
+- `DocNode` methods `AsInt()`, `AsFloat()`, `AsString()`, `AsBool()` have been removed. You can either add your own extension methods or change to use `As<>()`
+- `index.bytes` is not needed for `FileSource`
+- `ConfigFileInfo.Size` is now 64-bits (`long`)
+- Logs require the define flag `DC_LOGGING_ENABLED`
+

--- a/demo/Assets/DarkConfig/UnityPlatform.cs
+++ b/demo/Assets/DarkConfig/UnityPlatform.cs
@@ -2,10 +2,14 @@
 
 namespace DarkConfig {
     public static class UnityPlatform {
-        public static void Setup() {
+        public static void Setup(bool hotloading = false) {
             UnityTypeReifiers.RegisterAll();
             Configs.LogCallback = Log;
             Configs.AssertCallback = (test, message) => Debug.Assert(test, message);
+
+            if (hotloading) {
+                SetupHotloadingManager();
+            }
         }
 
         static void Log(LogVerbosity verbosity, string message) {
@@ -13,6 +17,26 @@ namespace DarkConfig {
                 case LogVerbosity.Error: Debug.LogError(message); break;
                 case LogVerbosity.Warn: Debug.LogWarning(message); break;
                 case LogVerbosity.Info: Debug.Log(message); break;
+            }
+        }
+
+        private static GameObject hotloadingManagerInstance = null;
+        static void SetupHotloadingManager() {
+            if (hotloadingManagerInstance != null) {
+                return;
+            }
+
+            hotloadingManagerInstance = new GameObject("DarkConfigHotloadingManager");
+            hotloadingManagerInstance.AddComponent<HotloadingManager>();
+        }
+
+        class HotloadingManager : MonoBehaviour {
+            void Awake() {
+                DontDestroyOnLoad(gameObject);
+            }
+
+            void Update() {
+                Configs.Update(Time.deltaTime);
             }
         }
     }

--- a/demo/Assets/DarkConfig/UnityTypeReifiers.cs
+++ b/demo/Assets/DarkConfig/UnityTypeReifiers.cs
@@ -7,6 +7,7 @@ namespace DarkConfig {
     public static class UnityTypeReifiers {
         public static void RegisterAll() {
             Configs.RegisterFromDoc<Vector2>(FromVector2);
+            Configs.RegisterFromDoc<Vector2Int>(FromVector2Int);
             Configs.RegisterFromDoc<Vector3>(FromVector3);
             Configs.RegisterFromDoc<Color>(FromColor);
         }
@@ -37,6 +38,33 @@ namespace DarkConfig {
 
             return new Vector2(x, y);
         }
+        static object FromVector2Int(object obj, DocNode value) {
+            // TODO (Graham): Make a non-boxing version of this?
+            // TODO (Graham): The scalar and n-dimensional support here is non-obvious. Those cases seem like they'd be nearly always mistakes. Better to throw an exception here.
+
+            var parsedType = value.Type;
+
+            // Parse a scalar int and use that for both components of the vector.
+            // 3 => new Vector2(3,3)
+            if (parsedType == DocNodeType.Scalar) {
+                var single = value.As<int>();
+                return new Vector2Int(single, single);
+            }
+
+            // Parse a list of ints and use those as the vector components.
+            // Supports the following conversions:
+            // [1] => Vector2Int(1,1)
+            // [1,2] => new Vector2Int(1,2);
+            // [1,2,3,4,5,6] => new Vector2Int(1,2);
+            int x = value[0].As<int>();
+            int y = x;
+            if (value.Count > 1) {
+                y = value[1].As<int>();
+            }
+
+            return new Vector2Int(x, y);
+        }
+
 
         static object FromVector3(object obj, DocNode value) {
             // TODO (Graham): Make a non-boxing version of this?

--- a/src/DarkConfig/Attributes.cs
+++ b/src/DarkConfig/Attributes.cs
@@ -17,3 +17,10 @@ public class ConfigAllowMissingAttribute : Attribute { }
 /// first place.
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 public class ConfigIgnoreAttribute : Attribute { }
+
+/// If a field has the SourceInformation attribute then the field is
+/// automaticaly populated with DocNode.SourceInformation by SetFieldsOnObject()
+/// Useful if you do validation or want better error reporting after reification
+/// Use #if flags to remove this in production code where it's not needed
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public class ConfigSourceInformationAttribute : Attribute { }

--- a/src/DarkConfig/Configs.cs
+++ b/src/DarkConfig/Configs.cs
@@ -184,6 +184,10 @@ namespace DarkConfig {
         public static List<string> GetFilenamesMatchingRegex(Regex pattern) {
             return FileManager.GetFilenamesMatchingRegex(pattern);
         }
+
+        public static ConfigFileInfo GetFileInfo(string filename) {
+            return FileManager.GetFileInfo(filename);
+        }
         
         #region Parsing YAML
         /// <summary>

--- a/src/DarkConfig/DocNode/ComposedDocNode.cs
+++ b/src/DarkConfig/DocNode/ComposedDocNode.cs
@@ -19,7 +19,7 @@ namespace DarkConfig {
                     scalar = "";
                     break;
                 default:
-                    throw new Exception($"Can't make a ComposedDocNode instance with Type {type}");
+                    throw new Exception($"Can't make a ComposedDocNode instance with Type {type} at {sourceInformation}");
             }
         }
 

--- a/src/DarkConfig/FileSource.cs
+++ b/src/DarkConfig/FileSource.cs
@@ -8,6 +8,8 @@ namespace DarkConfig {
     /// Uses file modified timestamps to decide whether it should hotload or not.
     public class FileSource : ConfigSource {
         public override bool CanHotload { get; }
+        /// If true, we till update the file modified time on disk with a checksum match, so hotloading won't check again next session
+        public bool SetModifiedTimeOnChecksumMatch = false;
                 
         ////////////////////////////////////////////
 
@@ -77,23 +79,34 @@ namespace DarkConfig {
                 
                 using (var fileStream = File.OpenRead(file)) {
                     int checksum = Internal.ChecksumUtils.Checksum(fileStream);
-                    fileStream.Seek(0, SeekOrigin.Begin);
-                    
-                    // Update the modified timestamp and file size even if the checksum is the same.
-                    // Because we didn't early out a few lines above, we know that at least one of these values
-                    // is stale.
-                    fileInfo.Modified = modified;
-                    fileInfo.Size = fileSize;
                     
                     if (checksum == fileInfo.Checksum) {
-                        // The files are identical.
+                        // The files are identical (according to the checksum)
+                        // Update the file size and modified timestamp
+                        // We didn't early out a few lines above, so we know that at least one of these values is stale.
+                        fileInfo.Size = fileSize;
+                        if (SetModifiedTimeOnChecksumMatch) {
+                            // Update the modified time on disk so we don't re-check this next session
+                            try {
+                                fileStream.Close();
+                                File.SetLastWriteTimeUtc(file, fileInfo.Modified);
+                                Configs.LogInfo($"Set mtime of file with matching checksum {fileInfo}");
+                            } catch (Exception e) {
+                                Configs.LogWarning($"Error setting mtime of file {fileInfo}: {e}"); // Warning cause execution can safely continue
+                                fileInfo.Modified = modified; // At least we won't reload this session
+                            }
+                        } else {
+                            fileInfo.Modified = modified;
+                        }
                         continue;
                     }
                     
                     // File has changed. Hotload it.
+                    fileStream.Seek(0, SeekOrigin.Begin);
+                    fileInfo.Parsed = Configs.LoadDocFromStream(fileStream, file);
                     fileInfo.Checksum = checksum;
                     fileInfo.Modified = modified;
-                    fileInfo.Parsed = Configs.LoadDocFromStream(fileStream, file);
+                    fileInfo.Size = fileSize;
                     
                     changedFiles.Add(fileName);
                 }

--- a/src/DarkConfig/Internal/ConfigFileManager.cs
+++ b/src/DarkConfig/Internal/ConfigFileManager.cs
@@ -213,6 +213,17 @@ namespace DarkConfig.Internal {
             return results;
         }
 
+        public ConfigFileInfo GetFileInfo(string filename) {
+            ThrowIfNotPreloaded();
+            
+            foreach (var source in sources) {
+                if (source.AllFiles.TryGetValue(filename, out var info)) {
+                    return info;
+                }
+            }
+            return null;
+        }
+
         /// If hotloading is enabled, triggers an immediate hotload.
         public void DoImmediateHotload() {
             if (!IsHotloadingFiles) {

--- a/src/DarkConfig/Internal/ConfigFileManager.cs
+++ b/src/DarkConfig/Internal/ConfigFileManager.cs
@@ -204,13 +204,13 @@ namespace DarkConfig.Internal {
         public List<string> GetFilenamesMatchingRegex(Regex pattern) {
             ThrowIfNotPreloaded();
             
-            var results = new List<string>();
+            var results = new HashSet<string>();
             
             foreach (var source in sources) {
                 RegexUtils.FilterMatching(pattern, source.AllFiles.Keys, results);
             }
             
-            return results;
+            return new List<string>(results);
         }
 
         public ConfigFileInfo GetFileInfo(string filename) {

--- a/src/DarkConfig/Internal/ConfigFileManager.cs
+++ b/src/DarkConfig/Internal/ConfigFileManager.cs
@@ -241,8 +241,9 @@ namespace DarkConfig.Internal {
                 }
             }
             
-            // Call callbacks for modified files.
+            // Log and call callbacks for modified files.
             foreach (string filename in modifiedFiles) {
+                Configs.LogInfo($"Hotloading: {filename}");
                 if (reloadCallbacks.TryGetValue(filename, out var callbacks)) {
                     for (int j = 0; j < callbacks.Count; j++) {
                         if (!callbacks[j](ParseFile(filename))) {

--- a/src/DarkConfig/Internal/ReflectionCache.cs
+++ b/src/DarkConfig/Internal/ReflectionCache.cs
@@ -24,6 +24,7 @@ namespace DarkConfig.Internal {
             public bool HasConfigMandatoryAttribute;
             public bool HasConfigAllowMissingAttribute;
             public bool HasConfigIgnoreAttribute;
+            public bool HasConfigSourceInformationAttribute;
         }
 
         [Flags]
@@ -137,6 +138,9 @@ namespace DarkConfig.Internal {
                     metadata.HasConfigAllowMissingAttribute = true;
                 } else if (attribute is ConfigIgnoreAttribute) {
                     metadata.HasConfigIgnoreAttribute = true;
+                }
+                if (attribute is ConfigSourceInformationAttribute) {
+                    metadata.HasConfigSourceInformationAttribute = true;
                 }
             }
         }

--- a/src/DarkConfig/Internal/RegexUtils.cs
+++ b/src/DarkConfig/Internal/RegexUtils.cs
@@ -12,7 +12,19 @@ namespace DarkConfig.Internal {
             }
         }
 
+        public static void FilterMatching(Regex pattern, IEnumerable<string> strings, HashSet<string> results) {
+            foreach (string str in strings) {
+                if (pattern.IsMatch(str)) {
+                    results.Add(str);
+                }
+            }
+        }
+
         public static void FilterMatchingGlob(string glob, IEnumerable<string> strings, List<string> results) {
+            FilterMatching(GlobToRegex(glob), strings, results);
+        }
+
+        public static void FilterMatchingGlob(string glob, IEnumerable<string> strings, HashSet<string> results) {
             FilterMatching(GlobToRegex(glob), strings, results);
         }
 

--- a/src/DarkConfig/Internal/TypeReifier.cs
+++ b/src/DarkConfig/Internal/TypeReifier.cs
@@ -385,6 +385,11 @@ namespace DarkConfig.Internal {
                     return existing;
                 }
 
+                // DocNode
+                if (fieldType == typeof(DocNode)) {
+                    return doc;
+                }
+
                 // Arrays
                 if (fieldType.IsArray) { 
                     int rank = fieldType.GetArrayRank();


### PR DESCRIPTION
Upstreaming a few minor improvements and tweaks, including:

- Hotloading log message (resolves #38)
- Add `ConfigSourceInformation` attribute to auto-populate with `DocNode.SourceInformation` in `SetFieldsOnObject()` (resolves #29)
- Fix bug where single-field classes with static fields aren't handled correctly (resolves #27)
- Reification support for `HashSet<>` (resolves #40)
- Add `Vector2Int` FromDoc for Unity (resolves #30)
- Add simple hotloading manager for Unity (resolves #33)
- Add migration doc (resolves #41)