### PR TITLE
Add support for Config Processors and a few other minor changes

### DIFF
--- a/src/DarkConfig/ConfigProcessor.cs
+++ b/src/DarkConfig/ConfigProcessor.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DarkConfig {
+    /// Processors can modify DocNodes after being parsed from YAML, but before used by the rest of the systems
+    /// Note: this is ONLY run on the YAML -> DocNode path, any other DocNode creation is not affected
+    public interface ConfigProcessor {
+        /// Does this processor potentially mutate data
+        /// Will make sure ComposedDocNode.MakeMutable() is run at least once before running this processor
+        public bool CanMutate { get; }
+
+        /// Process the DocNode here
+        public void Process(string filename, ref DocNode doc);
+    }
+}

--- a/src/DarkConfig/DarkConfig.csproj
+++ b/src/DarkConfig/DarkConfig.csproj
@@ -52,6 +52,7 @@
         <Compile Include="Attributes.cs" />
         <Compile Include="Configs.cs" />
         <Compile Include="ConfigFileInfo.cs" />
+        <Compile Include="ConfigProcessor.cs" />
         <Compile Include="ConfigSource.cs" />
         <Compile Include="DocNode\ComposedDocNode.cs" />
         <Compile Include="DocNode\DocNode.cs" />

--- a/src/DarkConfig/DocNode/DocNode.cs
+++ b/src/DarkConfig/DocNode/DocNode.cs
@@ -132,6 +132,32 @@ namespace DarkConfig {
             return false;
         }
 
+        /// Get a hash code for this DocNode that depends on its content, recursively
+        /// Note: can be expensive for large structures
+        public int GetDeepHashCode() {
+            switch (Type) {
+                case DocNodeType.Scalar:
+                    return StringValue.GetHashCode();
+
+                case DocNodeType.List:
+                    int seqHash = 0;
+                    foreach (var elem in Values) {
+                        seqHash ^= elem.GetDeepHashCode();
+                    }
+                    return seqHash;
+
+                case DocNodeType.Dictionary:
+                    int mapHash = 0;
+                    foreach (var kv in Pairs) {
+                        mapHash ^= kv.Key.GetHashCode() ^ kv.Value.GetDeepHashCode();
+                    }
+                    return mapHash;
+
+                default:
+                    throw new Exception($"Cannot calculate hash code for DocNode type {Type} at: {SourceInformation}");
+            }
+        }
+
         /// combines hierarchies.
         /// lists are concatenated, but dicts are recursively DeepMerged. 
         /// favours rhs on any conflict.


### PR DESCRIPTION
This adds support for Config Processors, which can run on DocNodes just after being parsed from YAML. Config Processors can transform and manipulate the DocNode, so you can add new functionality to DarkConfig more easily.

Resolves #32 