### PR TITLE
Reduce confusing output when encountering a parse exception

### DIFF
--- a/src/DarkConfig/Configs.cs
+++ b/src/DarkConfig/Configs.cs
@@ -166,7 +166,7 @@ namespace DarkConfig {
             var result = new ComposedDocNode(DocNodeType.Dictionary, count, sourceInformation);
             foreach (var doc in docs) {
                 if (doc.Type != DocNodeType.Dictionary) {
-                    throw new ParseException("Expected all DocNodes to be dictionaries in CombineDict.");
+                    throw new ParseException(doc, "Expected all DocNodes to be dictionaries in CombineDict.");
                 }
 
                 foreach ((string key, var value) in doc.Pairs) {

--- a/src/DarkConfig/DocNode/DocNode.cs
+++ b/src/DarkConfig/DocNode/DocNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace DarkConfig {
@@ -158,7 +158,7 @@ namespace DarkConfig {
                     return mapHash;
 
                 default:
-                    throw new Exception($"Cannot calculate hash code for DocNode type {Type} at: {SourceInformation}");
+                    throw new ParseException(this, $"Cannot calculate hash code for DocNode type {Type}");
             }
         }
 

--- a/src/DarkConfig/DocNode/YamlDocNode.cs
+++ b/src/DarkConfig/DocNode/YamlDocNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using YamlDotNet.RepresentationModel;
@@ -27,7 +27,7 @@ namespace DarkConfig {
             }
         }
 
-        public override string SourceInformation => $"File: {filename}, {node.Start}";
+        public override string SourceInformation => $"File: {filename}, Line: {node.Start.Line}, Col: {node.Start.Column}";
 
         /// <summary>
         /// Access the node as if it was a list

--- a/src/DarkConfig/Exceptions.cs
+++ b/src/DarkConfig/Exceptions.cs
@@ -12,27 +12,27 @@ namespace DarkConfig {
     /// bottom.  It's a bit more readable, and most importantly the line
     /// numbers in the config files are much more prominent.
     public class ParseException : Exception {
-        public ParseException(string message) : base(message) {
-            wrappedException = null;
+        public ParseException(DocNode exceptionNode, string message, Exception inner = null) : base((inner != null ? inner.Message + "\n" : "") + message) {
+            _node = exceptionNode;
+            _wrappedException = inner;
         }
 
-        public ParseException(string message, Exception inner) : base((inner != null ? inner.Message : "") + "\n" + message) {
-            wrappedException = inner;
+        public override string StackTrace => _wrappedException == null ? base.StackTrace : _wrappedException.StackTrace + "\n-----\n" + base.StackTrace;
+        public override string Message => base.Message + (HasNode ? $" from {_node.SourceInformation}" : "");
+        public bool HasNode {
+            get { return _node != null; }
         }
 
-        public override string StackTrace => wrappedException == null ? base.StackTrace : wrappedException.StackTrace + "\n-----\n" + base.StackTrace;
-
-        readonly Exception wrappedException;
+        readonly DocNode _node;
+        readonly Exception _wrappedException;
     }
 
     public class MissingFieldsException : ParseException {
-        public MissingFieldsException(string message) : base(message) { }
-        public MissingFieldsException(string message, Exception inner) : base(message, inner) { }
+        public MissingFieldsException(DocNode node, string message) : base(node, message) { }
     }
 
     public class ExtraFieldsException : ParseException {
-        public ExtraFieldsException(string message) : base(message) { }
-        public ExtraFieldsException(string message, Exception inner) : base(message, inner) { }
+        public ExtraFieldsException(DocNode node, string message) : base(node, message) { }
     }
 
     public class ConfigFileNotFoundException : FileNotFoundException {

--- a/src/DarkConfig/Internal/BuiltInTypeReifiers.cs
+++ b/src/DarkConfig/Internal/BuiltInTypeReifiers.cs
@@ -9,7 +9,7 @@ namespace DarkConfig.Internal {
         internal static object FromTimeSpan(object existing, DocNode doc) {
             bool isSuccess = TimeSpan.TryParse(doc.StringValue, out var newSpan);
             if (!isSuccess) {
-                throw new ParseException("expected parseable timespan string " + doc.StringValue, null);
+                throw new ParseException(doc, "expected parseable timespan string " + doc.StringValue);
             }
 
             return newSpan;

--- a/src/DarkConfig/Internal/TypeReifier.cs
+++ b/src/DarkConfig/Internal/TypeReifier.cs
@@ -110,7 +110,7 @@ namespace DarkConfig.Internal {
 
             // Check whether any required members in the type were not set.
             if (missingRequiredMemberNames != null && missingRequiredMemberNames.Count > 0) {
-                throw new MissingFieldsException($"Missing doc fields: {JoinList(missingRequiredMemberNames, ", ")} {doc.SourceInformation}");
+                throw new MissingFieldsException(doc, $"Missing doc fields: {JoinList(missingRequiredMemberNames, ", ")}");
             }
 
             // Check whether any fields in the doc were unused.
@@ -125,14 +125,14 @@ namespace DarkConfig.Internal {
                 }
 
                 if (extraDocFields.Count > 0) {
-                    throw new ExtraFieldsException($"Extra doc fields: {JoinList(extraDocFields, ", ")} {doc.SourceInformation}");
+                    throw new ExtraFieldsException(doc, $"Extra doc fields: {JoinList(extraDocFields, ", ")}");
                 }
             }
         }
 
         /// <summary>
         /// Sets a single field value on an object from the given docnode dict.
-        /// 
+        ///
         /// This is mostly only useful as a helper when writing FromDoc's
         /// </summary>
         /// <param name="obj">The object to set the field on</param>
@@ -241,7 +241,7 @@ namespace DarkConfig.Internal {
                             arrayValue = Array.CreateInstance(elementType, doc.Count);
                         } else if (arrayValue.Length != doc.Count) {
                             // Copy the existing values to the new array so we can feed them
-                            // in as existing values when reading array elements. 
+                            // in as existing values when reading array elements.
                             var oldArr = arrayValue;
                             arrayValue = Array.CreateInstance(elementType, doc.Count);
                             int numToCopy = Math.Min(oldArr.Length, arrayValue.Length);
@@ -256,7 +256,7 @@ namespace DarkConfig.Internal {
                         }
                     } else { // n-dimensional arrays
                         if (doc.Count == 0) {
-                            // Return a zero-length array of the correct dimensions. 
+                            // Return a zero-length array of the correct dimensions.
                             return Array.CreateInstance(elementType, new int[rank]);
                         }
 
@@ -460,8 +460,8 @@ namespace DarkConfig.Internal {
                 }
 
                 return existing;
-            } catch (Exception e) {
-                throw new ParseException($"Exception based on document starting at: {doc.SourceInformation}", e);
+            } catch (Exception e) when (!((e as ParseException)?.HasNode ?? false)) {
+                throw new ParseException(doc, $"Encountered exception", e);
             }
         }
 
@@ -508,9 +508,9 @@ namespace DarkConfig.Internal {
                 // Allow specifying object types with a single property or field as a scalar value in configs.
                 // This is syntactic sugar that lets us wrap values in classes.
                 if (typeInfo.FieldNames.Count + typeInfo.PropertyNames.Count != 1) {
-                    throw new Exception($"Trying to set a value of type: {type} {typeInfo.FieldNames.Count + typeInfo.PropertyNames.Count}"
+                    throw new ParseException(doc, $"Trying to set a value of type: {type} {typeInfo.FieldNames.Count + typeInfo.PropertyNames.Count}"
                         + $" from value of wrong type: " +
-                        (doc.Type == DocNodeType.Scalar ? doc.StringValue : doc.Type.ToString()) + $" at {doc.SourceInformation}");
+                        (doc.Type == DocNodeType.Scalar ? doc.StringValue : doc.Type.ToString()));
                 }
 
                 if (typeInfo.FieldNames.Count > 0) {
@@ -573,7 +573,7 @@ namespace DarkConfig.Internal {
 
             // Throw an error if any required fields in the class were unset
             if (missingRequiredMembers != null) {
-                throw new MissingFieldsException($"Missing doc fields: {JoinList(missingRequiredMembers, ", ")} {doc.SourceInformation}");
+                throw new MissingFieldsException(doc, $"Missing doc fields: {JoinList(missingRequiredMembers, ", ")}");
             }
 
             // Check whether any fields in the doc were unused
@@ -585,7 +585,7 @@ namespace DarkConfig.Internal {
                         extraDocFields.Add(kv.Key);
                     }
                 }
-                throw new ExtraFieldsException($"Extra doc fields: {JoinList(extraDocFields, ", ")} {doc.SourceInformation}");
+                throw new ExtraFieldsException(doc, $"Extra doc fields: {JoinList(extraDocFields, ", ")}");
             }
 
             obj = setCopy;
@@ -627,7 +627,7 @@ namespace DarkConfig.Internal {
 
                 if (!docHasKey) {
                     if (fieldIndex < typeInfo.NumRequiredFields) {
-                        throw new MissingFieldsException($"Missing doc field: {memberName} {doc.SourceInformation}");
+                        throw new MissingFieldsException(doc, $"Missing doc field: {memberName}");
                     }
                     return false;
                 }
@@ -645,7 +645,7 @@ namespace DarkConfig.Internal {
 
                 if (!docHasKey) {
                     if (propertyIndex < typeInfo.NumRequiredProperties) {
-                        throw new MissingFieldsException($"Missing doc field: {memberName} {doc.SourceInformation}");
+                        throw new MissingFieldsException(doc, $"Missing doc field: {memberName}");
                     }
                     return false;
                 }
@@ -686,7 +686,7 @@ namespace DarkConfig.Internal {
             }
 
             if (!allowExtra) {
-                throw new ExtraFieldsException($"Extra doc fields: {memberName} {doc.SourceInformation}");
+                throw new ExtraFieldsException(doc, $"Could not find a member named {memberName} on type {type.Name}");
             }
 
             return false;


### PR DESCRIPTION
Every layer of the parsing stack would re-catch and wrap the exceptions from the higher layers even if they didn't add any information, causing additional "line attribution" to the output that just made things confusing. This only re-wraps it if it doesn't have line number information already.